### PR TITLE
[003-EMAIL-VERIFICATION] Customer Email Verification

### DIFF
--- a/src/main/java/com/zerobase/cms/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/cms/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.zerobase.cms.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+  ALREADY_REGISTER_USER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
+  WRONG_VERIFICATION(HttpStatus.BAD_REQUEST, "잘못된 인증 시도입니다."),
+  EXPIRE_CODE(HttpStatus.BAD_REQUEST, "인증 시간이 만료되었습니다.."),
+  NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "일치하는 회원이 없습니다."),
+  ALREADY_VERIFY(HttpStatus.BAD_REQUEST, "이미 인증이 완료되었습니다.");
+
+
+  private final HttpStatus httpStatus;
+  private final String detail;
+}

--- a/src/main/java/com/zerobase/cms/exception/ExceptionController.java
+++ b/src/main/java/com/zerobase/cms/exception/ExceptionController.java
@@ -1,0 +1,32 @@
+package com.zerobase.cms.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class ExceptionController {
+
+  @ExceptionHandler({CustomException.class})
+
+  public ResponseEntity<ExceptionResponse> customRequestException(final CustomException c) {
+    log.warn("api Exception : {} ", c.getErrorCode());
+    return ResponseEntity.badRequest().body(new ExceptionResponse(c.getMessage(), c.getErrorCode()));
+  }
+
+  @Getter
+  @ToString
+  @AllArgsConstructor
+  public static class ExceptionResponse {
+
+    private String message;
+    private ErrorCode errorCode;
+  }
+
+}


### PR DESCRIPTION
Changes
---
feat : [003-EMAIL-VERIFICATION] Customer Email Verification
1. 회원가입시 인증번호 포함한 이메일 발송 : 유효기간 1일
2. 발송된 이메일 링크 클릭 시 로그인 기능

Background
---
Key가 노출될 경우 Mailgun에서 Github에 Scan을 걸어서 자동으로 Block 시켜버림 
가이드에 따라  Key를 변경하고, repository를 private로 변경한 다음 메일을 보낼것